### PR TITLE
Fix: Correctly load core file after rbe encryption

### DIFF
--- a/Parsa_Point_to_Component/parsa_point_to_component.rb
+++ b/Parsa_Point_to_Component/parsa_point_to_component.rb
@@ -6,7 +6,7 @@ module Parsa
     PLUGIN_PATH = File.dirname(__FILE__)
     EXTENSION = SketchupExtension.new(
       "Parsa Point to Component",
-      File.join(PLUGIN_PATH, "parsa_point_to_component", "core.rb")
+      File.join(PLUGIN_PATH, "parsa_point_to_component", "core")
     )
     EXTENSION.version     = "1.0.0"
     EXTENSION.creator     = "Parsa"


### PR DESCRIPTION
The Extension Warehouse encrypts .rb files to .rbe. This commit updates the path in the main plugin file to load 'core' instead of 'core.rb', allowing SketchUp to find and load the encrypted 'core.rbe' file.

This addresses the loading error you reported during extension review.