### PR TITLE
Fix: Update extension loading to use Sketchup.require

### DIFF
--- a/Parsa_Point_to_Component/parsa_point_to_component/core.rb
+++ b/Parsa_Point_to_Component/parsa_point_to_component/core.rb
@@ -1,3 +1,3 @@
-require_relative 'point_selector'
-require_relative 'csv_importer'
-require_relative 'ui'
+Sketchup.require 'parsa_point_to_component/point_selector'
+Sketchup.require 'parsa_point_to_component/csv_importer'
+Sketchup.require 'parsa_point_to_component/ui'


### PR DESCRIPTION
I replaced `require_relative` with `Sketchup.require` in `core.rb` to ensure compatibility with SketchUp's extension encryption. This resolves the load error you reported during extension review.

I also reviewed UI elements for trailing colons in headers as per your feedback; no such colons were found.